### PR TITLE
RDKBACCL-1275: wwan0 IP is not available in LTE (cellular) mode

### DIFF
--- a/source/CellularManager/cellularmgr_cellular_apis.c
+++ b/source/CellularManager/cellularmgr_cellular_apis.c
@@ -634,6 +634,9 @@ int CellularMgrUpdatePhyStatus ( char *wan_ifname, CellularDeviceOpenStatus_t de
             return RETURN_ERROR;
         }
 
+        //RDK-WanManager expects interface to be up and running
+        v_secure_system("ip link set %s up", wan_ifname);
+
         // Set Phy.Status
         memset( paramName, 0, sizeof(paramName) );
         memset( paramValue, 0, sizeof(paramValue) );


### PR DESCRIPTION
Reason for change: RDK-WanManager expects wwan0 interface to be up and running
Test procedure: Found that wwan0 is assigned with IPv4 address
Risks: Low